### PR TITLE
#62 & #86: Update def and stab match up table to handle having or not having an ability that affects them

### DIFF
--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -4,19 +4,19 @@ import { LoadedType } from "./loading/types";
 import { PokemonType } from "./types/PokemonType";
 
 function loadType(item: LoadedType): PokemonType {
-    return { ...item, id: item.key };
+    return new PokemonType(
+        item.key,
+        item.index,
+        item.name,
+        item.weaknesses,
+        item.resistances,
+        item.immunities,
+        item.isRealType
+    );
 }
 
 export const types: Record<string, PokemonType> = Object.fromEntries(
     Object.entries(loadedTypes).map(([id, monType]) => [id, loadType(monType)])
 );
 
-export const nullType: PokemonType = {
-    id: "",
-    name: "",
-    index: 0,
-    weaknesses: "",
-    resistances: "",
-    immunities: "",
-    isRealType: false,
-};
+export const nullType = new PokemonType("", 0, "", "", "", "", false);

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -3,20 +3,20 @@ import loadedTypes from "public/data/types.json";
 import { LoadedType } from "./loading/types";
 import { PokemonType } from "./types/PokemonType";
 
-function loadType(item: LoadedType): PokemonType {
-    return new PokemonType(
-        item.key,
-        item.index,
-        item.name,
-        item.weaknesses,
-        item.resistances,
-        item.immunities,
-        item.isRealType
-    );
+function loadType(type: LoadedType): PokemonType {
+    return new PokemonType(type);
 }
 
 export const types: Record<string, PokemonType> = Object.fromEntries(
     Object.entries(loadedTypes).map(([id, monType]) => [id, loadType(monType)])
 );
 
-export const nullType = new PokemonType("", 0, "", "", "", "", false);
+export const nullType = new PokemonType({
+    key: "",
+    index: 0,
+    name: "",
+    weaknesses: "",
+    resistances: "",
+    immunities: "",
+    isRealType: false,
+});

--- a/src/app/data/types/PokemonType.ts
+++ b/src/app/data/types/PokemonType.ts
@@ -1,3 +1,5 @@
+import { LoadedType } from "../loading/types";
+
 export class PokemonType {
     id: string;
     index: number;
@@ -7,22 +9,14 @@ export class PokemonType {
     immunities: string;
     isRealType: boolean;
 
-    constructor(
-        id: string,
-        index: number,
-        name: string,
-        weaknesses: string,
-        resistances: string,
-        immunities: string,
-        isRealType: boolean
-    ) {
-        this.id = id;
-        this.index = index;
-        this.name = name;
-        this.weaknesses = weaknesses;
-        this.resistances = resistances;
-        this.immunities = immunities;
-        this.isRealType = isRealType;
+    constructor(type: LoadedType) {
+        this.id = type.key;
+        this.index = type.index;
+        this.name = type.name;
+        this.weaknesses = type.weaknesses;
+        this.resistances = type.resistances;
+        this.immunities = type.immunities;
+        this.isRealType = type.isRealType;
     }
 
     getShortName(): string {

--- a/src/app/data/types/PokemonType.ts
+++ b/src/app/data/types/PokemonType.ts
@@ -1,4 +1,4 @@
-export interface PokemonType {
+export class PokemonType {
     id: string;
     index: number;
     name: string;
@@ -6,4 +6,26 @@ export interface PokemonType {
     resistances: string;
     immunities: string;
     isRealType: boolean;
+
+    constructor(
+        id: string,
+        index: number,
+        name: string,
+        weaknesses: string,
+        resistances: string,
+        immunities: string,
+        isRealType: boolean
+    ) {
+        this.id = id;
+        this.index = index;
+        this.name = name;
+        this.weaknesses = weaknesses;
+        this.resistances = resistances;
+        this.immunities = immunities;
+        this.isRealType = isRealType;
+    }
+
+    getShortName(): string {
+        return this.name.substring(0, 3).toUpperCase();
+    }
 }

--- a/src/components/TypeBadgeSingle.tsx
+++ b/src/components/TypeBadgeSingle.tsx
@@ -1,10 +1,15 @@
 import { PokemonType } from "@/app/data/types/PokemonType";
 import { getTypeBadgeColourClass } from "./colours";
 
-export default function TypeBadgeHeader({ type }: { type: PokemonType }) {
+interface TypeBadgeHeaderProps {
+    type: PokemonType;
+    useShort: boolean;
+}
+
+export default function TypeBadgeHeader({ type, useShort }: TypeBadgeHeaderProps) {
     return (
-        <th className={`px-2 py-1 rounded-full text-white text-xs font-semibold ${getTypeBadgeColourClass(type)}`}>
-            {type.name}
+        <th className={`py-2 text-white text-xs font-semibold ${getTypeBadgeColourClass(type)}`}>
+            {useShort ? type.getShortName() : type.name}
         </th>
     );
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9cdde925-e8b4-4ce7-afc8-e555b76bef01)
![image](https://github.com/user-attachments/assets/b2888e40-a358-4142-a3eb-9ce82f9a4626)
![image](https://github.com/user-attachments/assets/e20ae895-9a18-476f-88d7-e8ee67585c84)
![image](https://github.com/user-attachments/assets/e3c007de-a825-427b-aa8b-4ae59ec86b04)
![image](https://github.com/user-attachments/assets/3e548512-4d9c-4d2e-b544-8d2c6a27854e)

UI is now slightly changed from before as I've split the type chart into 2 rows, similar to how PokemonDB does it. 
This way the user doesn't have to scroll to see more. 