### PR TITLE
Implement Heavy Slam

### DIFF
--- a/src/app/data/moves.ts
+++ b/src/app/data/moves.ts
@@ -16,7 +16,8 @@ import { SpitUpMove } from "./moves/SpitUpMove";
 import { StackingMove } from "./moves/StackingMove";
 import { SuperAdaptiveMove } from "./moves/SuperAdaptiveMove";
 import { VariableTypeMove, variableTypeMoves } from "./moves/TypeFromItemMove";
-import { WeightScalingMove } from "./moves/WeightScalingMove";
+import { WeightTargetScalingMove } from "./moves/WeightTargetScalingMove";
+import { WeightUserScalingMove } from "./moves/WeightUserScalingMove";
 import { Move } from "./types/Move";
 
 const moveSubclasses = [
@@ -36,7 +37,8 @@ const moveSubclasses = [
     StackingMove,
     SuperAdaptiveMove,
     // VariableTypeMove is handled separately
-    WeightScalingMove,
+    WeightTargetScalingMove,
+    WeightUserScalingMove,
 ];
 
 function loadMove(move: LoadedMove): Move {

--- a/src/app/data/moves/WeightTargetScalingMove.ts
+++ b/src/app/data/moves/WeightTargetScalingMove.ts
@@ -1,7 +1,7 @@
 import { Move } from "../types/Move";
 import { PartyPokemon } from "../types/PartyPokemon";
 
-export class WeightScalingMove extends Move {
+export class WeightTargetScalingMove extends Move {
     public getPower(_: PartyPokemon, target: PartyPokemon): number {
         let ret = 15;
         // Formula differs from Tectonic - they store weight in kg/10ths

--- a/src/app/data/moves/WeightUserScalingMove.ts
+++ b/src/app/data/moves/WeightUserScalingMove.ts
@@ -1,0 +1,16 @@
+import { Move } from "../types/Move";
+import { PartyPokemon } from "../types/PartyPokemon";
+
+export class WeightUserScalingMove extends Move {
+    public getPower(user: PartyPokemon, target: PartyPokemon): number {
+        let ret = 40;
+        // weight differs from here to tectonic, but by a consistent factor
+        // so this division should always be the same
+        let ratio = user.species.weight / target.species.weight;
+        ratio = Math.min(ratio, 10);
+        ret += Math.floor((16 * ratio ** 0.75) / 5) * 5;
+        return ret;
+    }
+
+    static moveCodes = ["ScalesHeavierThanTarget"];
+}


### PR DESCRIPTION
Currently bugged. Power seems to be *higher* for heavier targets, and is not a multiple of 5 despite the last step being a multiplication by 5 after a floor. No idea what's going on, but I'm on an early morning roll through easy tasks so I'm leaving this to investigate later.