### PR TITLE
Make object null checking consistent

### DIFF
--- a/src/app/data/typeChart.ts
+++ b/src/app/data/typeChart.ts
@@ -92,7 +92,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
 
     let defType2Calc = 1.0;
     let defAbilityCalc = 1.0;
-    if (def.type2 !== undefined) {
+    if (!isNull(def.type2)) {
         const defType2 = def.type2;
         defType2Calc = typeChart[atkType.index][defType2.index];
         // certain moves pierce ground immunity
@@ -101,7 +101,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
         }
     }
     const defAbility = def.ability;
-    if (defAbility !== undefined) {
+    if (!isNull(defAbility)) {
         const immunityMatch = immunityAbilities.find((x) => x.ability == defAbility.id);
         const halfMatch = halfDmgAbilities.find((x) => x.ability == defAbility.id);
         const doubleMatch = doubleTakenAbilities.find((x) => x.ability == defAbility.id);
@@ -139,7 +139,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
     let atkAbilityCalc = 1.0;
     let atkMoveCalc = 1;
     const atkAbility = atk.ability;
-    if (atkAbility !== undefined) {
+    if (!isNull(atkAbility)) {
         if (atkAbility.flags.includes("MoldBreaking")) {
             defAbilityCalc = 1.0;
         } else if (atkAbility.id == "BREAKTHROUGH") {
@@ -175,7 +175,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
 
 export function calcBestMoveMatchup(mon: PartyPokemon, def: DefenderData): number {
     const calcs = mon.moves
-        .filter((m) => m != undefined && !isNull(m) && m.isAttackingMove())
+        .filter((m) => !isNull(m) && m.isAttackingMove())
         .map((m) => calcTypeMatchup({ type: m.type, move: m, ability: mon.ability }, def));
     return calcs.length > 0 ? Math.max(...calcs) : 1;
 }

--- a/src/app/data/util.ts
+++ b/src/app/data/util.ts
@@ -5,7 +5,10 @@ import { Pokemon } from "./types/Pokemon";
 import { PokemonType } from "./types/PokemonType";
 import { Trainer } from "./types/Trainer";
 
-export function isNull(o: Pokemon | Move | Trainer | Ability | Item | PokemonType | undefined): boolean {
+type NullableObject = Pokemon | Move | Trainer | Ability | Item | PokemonType;
+type NullObject = NullableObject & { name: "" };
+
+export function isNull(o: NullableObject | undefined): o is undefined | NullObject {
     return !o || o.name === "";
 }
 

--- a/src/components/TypeBadge.tsx
+++ b/src/components/TypeBadge.tsx
@@ -1,4 +1,5 @@
 import { PokemonType } from "@/app/data/types/PokemonType";
+import { isNull } from "@/app/data/util";
 import { getTypeColorClass } from "./colours";
 
 export enum TypeBadgeElementEnum {
@@ -29,7 +30,8 @@ export default function TypeBadge({ types, useShort, element }: TypeBadgeProps) 
         return useShort ? type.getShortName() : type.name;
     }
 
-    const defTypes = types.filter((type) => type != undefined);
+    // have to manually assert type here because Array.filter doesn't typeguard properly :(
+    const defTypes = types.filter((type) => !isNull(type)) as PokemonType[];
     switch (element) {
         case TypeBadgeElementEnum.TABLE_HEADER:
             return <th className={`${getClasses(defTypes[0]!)} w-12`}>{getText(defTypes[0]!)}</th>;


### PR DESCRIPTION
Related to #128.

Always use `isNull` rather than comparing to undefined. This will allow more flexibility in the future depending on how we decide to handle null object values. This PR does not include actually making a decision on that, where things are currently somewhat inconsistent between representing an unselected object as undefined or the corresponding null object.

Leaving PR open for a bit to double check that I didn't miss any instances. I searched the codebase for `= undefined` (which should include both `== undefined` and `!= undefined`), but obviously there are false positives where variables are primitives and an undefined check *is* appropriate, so it would be easy for one to have blended in. There may also be another syntax I'm not thinking of that would escape this search.