### PR TITLE
#188 - Fix parsing of tribes with commas in their description

### DIFF
--- a/src/preload/loadedDataClasses.ts
+++ b/src/preload/loadedDataClasses.ts
@@ -4,6 +4,7 @@ import { uniq } from "@/app/data/util";
 // Note that the extending classes use statics in order to avoid fields from showing up in the output JSON
 export abstract class LoadedData<SubClass extends LoadedData<SubClass>> {
     static bracketKeyName: string = "Bracketvalue";
+    static commaDeliminatedLine: string = "CommaLine";
     static completedLoading: string = "completedLoading";
 
     key: string = "";
@@ -76,16 +77,29 @@ export class LoadedTribe extends LoadedData<LoadedTribe> {
 
     static populateMap: Record<string, (version: string, self: LoadedTribe, value: string) => void> = {};
     static {
-        this.populateMap["0"] = (version, self, value) => {
-            self.key = value;
-            if (version.startsWith("3.2")) self.name = self.key[0] + self.key.substring(1).toLowerCase();
+        this.populateMap[LoadedData.commaDeliminatedLine] = (version, self, value) => {
+            function getDesc(startIndex: number): string {
+                // The description may have commas, but is at the end. So join the whole thing
+                return split
+                    .slice(startIndex)
+                    .join()
+                    .replaceAll('"', "")
+                    .replaceAll(" and is currently {b}", "")
+                    .replaceAll(" and is currently {b1}", "");
+            }
+
+            const split = value.split(",");
+            self.key = split[0];
+            self.activationCount = parseInt(split[1]);
+
+            if (version.startsWith("3.2")) {
+                self.name = self.key[0] + self.key.substring(1).toLowerCase();
+                self.description = getDesc(2);
+            } else {
+                self.name = split[2];
+                self.description = getDesc(3);
+            }
         };
-        this.populateMap["1"] = (_, self, value) => (self.activationCount = parseInt(value));
-        this.populateMap["2"] = (version, self, value) => {
-            if (version.startsWith("3.2")) self.description = value.replaceAll('"', "");
-            else self.name = value;
-        };
-        this.populateMap["3"] = (_, self, value) => (self.description = value.replaceAll('"', ""));
     }
 }
 

--- a/src/preload/tectonicFileParsers.ts
+++ b/src/preload/tectonicFileParsers.ts
@@ -74,8 +74,9 @@ export function parseNewLineCommaFile<T extends LoadedData<T>>(
     file.split(/\r?\n/)
         .filter((line) => line.length > 0)
         .forEach((line) => {
-            const splitKV = line.split(",").map((x, index) => new KVPair(index.toString(), x));
-            const value = LoadedData.populate(tectonicVersion, new ctor(), populateMap, splitKV);
+            const value = LoadedData.populate(tectonicVersion, new ctor(), populateMap, [
+                new KVPair(LoadedData.commaDeliminatedLine, line),
+            ]);
             map[value.key] = value;
         });
 


### PR DESCRIPTION
Quick fix for tribes that have commas in their description losing all the description after the first comma