### PR TITLE
Added a height to the type chart cell

### DIFF
--- a/src/app/pokedex/components/TypeChartCell.tsx
+++ b/src/app/pokedex/components/TypeChartCell.tsx
@@ -85,7 +85,7 @@ export default function TypeChartCell({ atk = undefined, def = undefined, mult =
 
     return (
         <td
-            className={`border border-gray-600 text-lg text-center cursor-default font-bold ${colourClass} ${textClass}`}
+            className={`border border-gray-600 text-lg text-center cursor-default font-bold h-[1.6em] ${colourClass} ${textClass}`}
             title={tooltip}
         >
             {content}


### PR DESCRIPTION
Looks like this if there's no text. If the actual displayed font size is bigger this size seems to act as a `min` even though it's not set using tailwind min-h
![image](https://github.com/user-attachments/assets/e57b8a55-46aa-4f9c-a443-fb883e92d83d)

Closes #183 