### PR TITLE
Move flags and target data

### DIFF
--- a/src/app/data/tectonic/Move.ts
+++ b/src/app/data/tectonic/Move.ts
@@ -48,6 +48,7 @@ export class Move {
     customVarType?: string;
     needsInput: boolean = false;
     isSignature: boolean = false;
+    flags: string[] = [];
 
     static NULL: Move = null!;
 
@@ -65,6 +66,7 @@ export class Move {
         this.category = loaded.category as MoveCategory;
         this.target = loaded.target as MoveTarget;
         this.isSignature = loaded.isSignature;
+        this.flags = loaded.flags;
     }
 
     public isAttackingMove() {
@@ -73,6 +75,56 @@ export class Move {
 
     public isSpread(): boolean {
         return spreadTargets.indexOf(this.target) > -1;
+    }
+
+    public getTargetPositions(): number[][] {
+        // Format is [[Foe, Foe], [User, Ally]]
+        switch (this.target) {
+            case "FoeSide":
+            case "NearFoe":
+            case "AllNearFoes":
+            case "ClosestNearFoe":
+                return [
+                    [1, 1],
+                    [0, 0],
+                ];
+            case "UserSide":
+            case "UserAndAllies":
+                return [
+                    [0, 0],
+                    [1, 1],
+                ];
+            case "UserOrNearOther":
+            case "AllNearOthers":
+            case "AllBattlers":
+            case "BothSides":
+                return [
+                    [1, 1],
+                    [1, 1],
+                ];
+            case "Ally":
+            case "NearAlly":
+                return [
+                    [0, 0],
+                    [0, 1],
+                ];
+            case "NearOther":
+                return [
+                    [1, 1],
+                    [0, 1],
+                ];
+            case "User":
+                return [
+                    [0, 0],
+                    [1, 0],
+                ];
+            case "None":
+            default:
+                return [
+                    [0, 0],
+                    [0, 0],
+                ];
+        }
     }
 
     public isSTAB(mon: Pokemon): boolean {

--- a/src/app/pokedex/components/MoveTable.tsx
+++ b/src/app/pokedex/components/MoveTable.tsx
@@ -4,17 +4,47 @@ import { TectonicData } from "@/app/data/tectonic/TectonicData";
 import FilterOptionButton from "@/components/FilterOptionButton";
 import TypeBadge, { TypeBadgeElementEnum } from "@/components/TypeBadge";
 import Image from "next/image";
-import { ReactNode, useState } from "react";
+import { Fragment, ReactNode, useState } from "react";
 
 function TableHeader({ children }: { children: ReactNode }) {
-    return <th className="px-2 py-3 text-center text-sm font-medium text-gray-500 dark:text-gray-300">{children}</th>;
+    return <th className="px-1 py-3 text-center text-sm font-bold text-gray-500 dark:text-gray-300">{children}</th>;
 }
 
-function TableCell({ children }: { children: ReactNode }) {
-    return <td className="border-y px-2 py-3 text-center text-sm text-gray-900 dark:text-gray-200">{children}</td>;
+function TableCell({ span, children }: { span?: number; children: ReactNode }) {
+    return (
+        <td
+            className="px-1 text-center text-sm text-gray-900 dark:text-gray-200 whitespace-break-spaces"
+            colSpan={span}
+        >
+            {children}
+        </td>
+    );
+}
+
+function MoveTargetCell({ move, position, children }: { move: Move; position: number[][]; children: ReactNode }) {
+    let useBg = 0;
+    move.getTargetPositions().forEach((a, i) => a.forEach((v, j) => (useBg += v * position[i][j])));
+
+    return (
+        <td className={`border px-2 py-0.5 text-xs dark:text-black ${useBg > 0 ? "bg-blue-300" : "bg-white/50"}`}>
+            {children}
+        </td>
+    );
 }
 
 export default function MoveTable({ moves, showLevel }: { moves: [number, Move][]; showLevel: boolean }) {
+    const displayableMoveFlags = new Set<string>();
+    displayableMoveFlags.add("Sound");
+    displayableMoveFlags.add("Punch");
+    displayableMoveFlags.add("Dance");
+    displayableMoveFlags.add("Blade");
+    displayableMoveFlags.add("Biting");
+    displayableMoveFlags.add("Bite");
+    displayableMoveFlags.add("Kicking");
+    displayableMoveFlags.add("Pulse");
+    displayableMoveFlags.add("Wind");
+    displayableMoveFlags.add("Foretold");
+
     const [selectedCategory, setSelectedCategory] = useState<MoveCategory | undefined>(undefined);
     const [selectedType, setSelectedType] = useState<PokemonType | undefined>(undefined);
 
@@ -41,20 +71,22 @@ export default function MoveTable({ moves, showLevel }: { moves: [number, Move][
                     </FilterOptionButton>
                 ))}
             </div>
-            <div className="grid grid-rows-2 grid-flow-col space-x-2 space-y-2 mb-3">
-                {Object.values(TectonicData.types).map((t) => (
-                    <FilterOptionButton
-                        key={t.id}
-                        onClick={() => setSelectedType(selectedType === t ? undefined : t)}
-                        isSelected={selectedType === t}
-                        padding="p-2"
-                    >
-                        <TypeBadge types={[t]} useShort={false} element={TypeBadgeElementEnum.ICONS} />
-                    </FilterOptionButton>
-                ))}
+            <div className="grid grid-rows-2 grid-flow-col justify-center space-x-3 space-y-3 mb-3">
+                {Object.values(TectonicData.types)
+                    .filter((t) => t.isRealType)
+                    .map((t) => (
+                        <FilterOptionButton
+                            key={t.id}
+                            onClick={() => setSelectedType(selectedType === t ? undefined : t)}
+                            isSelected={selectedType === t}
+                            padding="p-2"
+                        >
+                            <TypeBadge types={[t]} useShort={false} element={TypeBadgeElementEnum.ICONS} />
+                        </FilterOptionButton>
+                    ))}
             </div>
-            <table className="w-full divide-gray-200 dark:divide-gray-700">
-                <thead className="sticky top-0 bg-gray-50 dark:bg-gray-700">
+            <table className="w-full">
+                <thead className="sticky top-0 text-gray-900 dark:text-gray-200 bg-blue-200 dark:bg-blue-700">
                     <tr>
                         {showLevel && <TableHeader>Lvl</TableHeader>}
                         <TableHeader>Name</TableHeader>
@@ -64,7 +96,8 @@ export default function MoveTable({ moves, showLevel }: { moves: [number, Move][
                         <TableHeader>Acc</TableHeader>
                         <TableHeader>PP</TableHeader>
                         <TableHeader>Prio</TableHeader>
-                        <TableHeader>Effect</TableHeader>
+                        <TableHeader>Flags</TableHeader>
+                        <TableHeader>Target</TableHeader>
                     </tr>
                 </thead>
                 <tbody>
@@ -75,35 +108,94 @@ export default function MoveTable({ moves, showLevel }: { moves: [number, Move][
                                 (selectedType === undefined || m.type === selectedType)
                         )
                         .map(([level, m], index) => (
-                            <tr key={index}>
-                                {showLevel && <TableCell>{level == 0 ? "E" : level}</TableCell>}
-                                <TableCell>
-                                    <span className={m.isSignature ? "text-yellow-500" : ""}>{m.name}</span>
-                                </TableCell>
-                                <TableCell>
-                                    <TypeBadge
-                                        key={m.type.id}
-                                        types={[m.type]}
-                                        useShort={false}
-                                        element={TypeBadgeElementEnum.ICONS}
-                                    />
-                                </TableCell>
-                                <TableCell>
-                                    <Image
-                                        src={`/move_categories/${m.category}.png`}
-                                        alt={m.category}
-                                        title={m.category}
-                                        height="60"
-                                        width="51"
-                                        className="w-8 h-6"
-                                    />
-                                </TableCell>
-                                <TableCell>{m.bp}</TableCell>
-                                <TableCell>{m.accuracy}</TableCell>
-                                <TableCell>{m.pp}</TableCell>
-                                <TableCell>{m.priority ?? "-"}</TableCell>
-                                <TableCell>{m.description}</TableCell>
-                            </tr>
+                            <Fragment key={index}>
+                                <tr className={index % 2 == 0 ? "" : "bg-gray-50 dark:bg-gray-700"}>
+                                    {showLevel && <TableCell>{level == 0 ? "E" : level}</TableCell>}
+                                    <TableCell>
+                                        <span className={m.isSignature ? "text-yellow-500" : ""}>{m.name}</span>
+                                    </TableCell>
+                                    <TableCell>
+                                        <TypeBadge
+                                            key={m.type.id}
+                                            types={[m.type]}
+                                            useShort={false}
+                                            element={TypeBadgeElementEnum.ICONS}
+                                        />
+                                    </TableCell>
+                                    <TableCell>
+                                        <Image
+                                            src={`/move_categories/${m.category}.png`}
+                                            alt={m.category}
+                                            title={m.category}
+                                            height="60"
+                                            width="51"
+                                            className="w-8 h-6 mx-auto"
+                                        />
+                                    </TableCell>
+                                    <TableCell>{m.bp}</TableCell>
+                                    <TableCell>{m.accuracy}</TableCell>
+                                    <TableCell>{m.pp}</TableCell>
+                                    <TableCell>{m.priority ?? "-"}</TableCell>
+                                    <TableCell>
+                                        {m.flags.filter((f) => displayableMoveFlags.has(f)).length == 0
+                                            ? "-"
+                                            : m.flags.filter((f) => displayableMoveFlags.has(f)).join("\n")}
+                                    </TableCell>
+                                    <TableCell>
+                                        <table className="mx-auto mt-3 mb-1">
+                                            <tbody>
+                                                <tr>
+                                                    <MoveTargetCell
+                                                        move={m}
+                                                        position={[
+                                                            [1, 0],
+                                                            [0, 0],
+                                                        ]}
+                                                    >
+                                                        Foe
+                                                    </MoveTargetCell>
+                                                    {m.isSpread() && (
+                                                        <MoveTargetCell
+                                                            move={m}
+                                                            position={[
+                                                                [0, 1],
+                                                                [0, 0],
+                                                            ]}
+                                                        >
+                                                            Foe
+                                                        </MoveTargetCell>
+                                                    )}
+                                                </tr>
+                                                <tr>
+                                                    <MoveTargetCell
+                                                        move={m}
+                                                        position={[
+                                                            [0, 0],
+                                                            [1, 0],
+                                                        ]}
+                                                    >
+                                                        User
+                                                    </MoveTargetCell>
+                                                    {m.isSpread() && (
+                                                        <MoveTargetCell
+                                                            move={m}
+                                                            position={[
+                                                                [0, 0],
+                                                                [0, 1],
+                                                            ]}
+                                                        >
+                                                            Ally
+                                                        </MoveTargetCell>
+                                                    )}
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </TableCell>
+                                </tr>
+                                <tr className={index % 2 == 0 ? "" : "bg-gray-50 dark:bg-gray-700"}>
+                                    <TableCell span={showLevel ? 10 : 9}>{m.description}</TableCell>
+                                </tr>
+                            </Fragment>
                         ))}
                 </tbody>
             </table>


### PR DESCRIPTION
Closes #42, #191, #193

- Added flag information for relevant flags, feel free to add to that list if there's more
- Added target info, feel free to correct anything there. I'm not 100% sure on how each target type works
- Moved description to below the other data to free up a bunch of space.

I'll make another issue for having the main pokedex use this move list as well now. Might add in sorting alongside that

![image](https://github.com/user-attachments/assets/098cdc44-3246-4d8b-b741-606edffbfa4b)

Some flags:
![image](https://github.com/user-attachments/assets/b0d3668e-002b-4939-9a8d-3d1c6bc9f13b)

