### PR TITLE
Ability table filters for team building

### DIFF
--- a/src/app/data/tectonic/Ability.ts
+++ b/src/app/data/tectonic/Ability.ts
@@ -23,5 +23,33 @@ export class Ability {
         return 1;
     }
 
+    public hasSunSynergy() {
+        return this.flags.includes("SunSynergy");
+    }
+
+    public hasRainSynergy() {
+        return this.flags.includes("RainstormSynergy");
+    }
+
+    public hasHailSynergy() {
+        return this.flags.includes("HailSynergy");
+    }
+
+    public hasSandSynergy() {
+        return this.flags.includes("SandSynergy");
+    }
+
+    public hasEclipseSynergy() {
+        return this.flags.includes("EclipseSynergy");
+    }
+
+    public hasMoonglowSynergy() {
+        return this.flags.includes("MoonglowSynergy");
+    }
+
+    public hasAllWeatherSynergy() {
+        return this.flags.includes("AllWeatherSynergy");
+    }
+
     static abilityIds: string[] = [];
 }

--- a/src/app/pokedex/page.tsx
+++ b/src/app/pokedex/page.tsx
@@ -18,6 +18,9 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import { useEffect, useMemo, useState } from "react";
 import { FilterInput } from "../../components/FilterInput";
+import { ExtraTypeAbility } from "../data/abilities/ExtraTypeAbility";
+import { TypeImmunityAbility } from "../data/abilities/TypeImmunityAbility";
+import { TypeResistAbility } from "../data/abilities/TypeResistAbility";
 import { Ability } from "../data/tectonic/Ability";
 import { Item } from "../data/tectonic/Item";
 import { Move } from "../data/tectonic/Move";
@@ -38,6 +41,27 @@ export interface PokemonTableProps {
 }
 
 const tabNames = ["Pokemon", "Moves", "Abilities", "Items", "Tribes", "Type Chart"];
+
+interface FilterableAbility {
+    label: string;
+    filter: (a: Ability) => boolean;
+}
+const filterableAbilities: FilterableAbility[][] = [
+    [
+        { label: "All Weather", filter: (a: Ability) => a.hasAllWeatherSynergy() },
+        { label: "Sun", filter: (a: Ability) => a.hasSunSynergy() },
+        { label: "Rain", filter: (a: Ability) => a.hasRainSynergy() },
+        { label: "Hail", filter: (a: Ability) => a.hasHailSynergy() },
+        { label: "Sand", filter: (a: Ability) => a.hasSandSynergy() },
+        { label: "Eclipse", filter: (a: Ability) => a.hasEclipseSynergy() },
+        { label: "Moonglow", filter: (a: Ability) => a.hasMoonglowSynergy() },
+    ],
+    [
+        { label: "Extra Type", filter: (a: Ability) => a instanceof ExtraTypeAbility },
+        { label: "Immunity", filter: (a: Ability) => a instanceof TypeImmunityAbility },
+        { label: "Resists", filter: (a: Ability) => a instanceof TypeResistAbility },
+    ],
+];
 
 const itemMons: Record<string, Array<Pokemon>> = {};
 Object.values(TectonicData.pokemon).forEach((x) =>
@@ -65,6 +89,7 @@ const Home: NextPage = () => {
     const [activeTab, setActiveTab] = useState<string>("Pokemon");
     const [currentFilter, setCurrentFilter] = useState<PokemonFilterType>(AVAILABLE_FILTERS[0]);
     const [itemFilter, setItemFilter] = useState<string | undefined>();
+    const [abilityTableFilter, setAbilityTableFilter] = useState<FilterableAbility>();
 
     const handleAddFilter = (filter: PokemonFilterType, value: string) => {
         setFilters((prev) => [...prev, { ...filter, value }]);
@@ -213,6 +238,23 @@ const Home: NextPage = () => {
                 </TabContent>
                 <TabContent tab="Abilities" activeTab={activeTab}>
                     <div className="overflow-x-auto">
+                        <div>
+                            {filterableAbilities.map((group, index) => (
+                                <div key={index} className="flex justify-center space-x-2 my-2">
+                                    {group.map((a) => (
+                                        <FilterOptionButton
+                                            key={a.label}
+                                            onClick={() =>
+                                                setAbilityTableFilter(abilityTableFilter === a ? undefined : a)
+                                            }
+                                            isSelected={abilityTableFilter === a}
+                                        >
+                                            {a.label}
+                                        </FilterOptionButton>
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
                         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                             <thead className="bg-gray-50 dark:bg-gray-800">
                                 <tr>
@@ -221,16 +263,18 @@ const Home: NextPage = () => {
                                 </tr>
                             </thead>
                             <tbody>
-                                {Object.values(TectonicData.abilities).map((a) => (
-                                    <tr
-                                        key={a.id}
-                                        onClick={() => handleAbilityClick(a)}
-                                        className={`hover:bg-blue-50 dark:hover:bg-blue-900 cursor-pointer`}
-                                    >
-                                        <TableCell>{a.name}</TableCell>
-                                        <TableCell>{a.description}</TableCell>
-                                    </tr>
-                                ))}
+                                {Object.values(TectonicData.abilities)
+                                    .filter((a) => (abilityTableFilter ? abilityTableFilter.filter(a) : true))
+                                    .map((a) => (
+                                        <tr
+                                            key={a.id}
+                                            onClick={() => handleAbilityClick(a)}
+                                            className={`hover:bg-blue-50 dark:hover:bg-blue-900 cursor-pointer`}
+                                        >
+                                            <TableCell>{a.name}</TableCell>
+                                            <TableCell>{a.description}</TableCell>
+                                        </tr>
+                                    ))}
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
Closes #206 

As mentioned in the issue I did not follow the subclassing pattern for the weather ability checks:
- Flags offer a more future proof / less maintenance way of checking 
- We don't care about what the ability does in this case, so subclassing is overkill
- I don't really know how you want the subclassing setup for the calculator for weather abilities, so this way is pretty simple and easy to replace later.

Filters have a focus on stuff that you'd use for team building. Let me know if there's others you'd like / know users would find useful. i just went with stuff I normally would check for when making a team

Techo style filtering used instead of the filter style on the pokemon table page because in this case abilities will always be uniquely filtered - ie. applying 2 filters is basically always going to be overkill and result in nothing. 

Note: I know the filters right below the page "filters" looks kinda odd. I want to update the page selection in another PR to feel more like a header and not be sticky (and instead have the page support a scroll to top floating button)

![image](https://github.com/user-attachments/assets/32028ec7-871f-4d38-af81-658035125da3)
![image](https://github.com/user-attachments/assets/b444cfb6-29b7-4072-8a16-1b290aa8a7fa)
