### PR TITLE
Use new move table in Pokedex

### DIFF
--- a/src/app/pokedex/components/MoveTable.tsx
+++ b/src/app/pokedex/components/MoveTable.tsx
@@ -32,7 +32,15 @@ function MoveTargetCell({ move, position, children }: { move: Move; position: bo
     );
 }
 
-export default function MoveTable({ moves, showLevel }: { moves: [number, Move][]; showLevel: boolean }) {
+export default function MoveTable({
+    moves,
+    showLevel,
+    onMoveClick = undefined,
+}: {
+    moves: [number, Move][];
+    showLevel: boolean;
+    onMoveClick?: (m: Move) => void;
+}) {
     const displayableMoveFlags = new Set<string>();
     displayableMoveFlags.add("Sound");
     displayableMoveFlags.add("Punch");
@@ -47,6 +55,10 @@ export default function MoveTable({ moves, showLevel }: { moves: [number, Move][
 
     const [selectedCategory, setSelectedCategory] = useState<MoveCategory | undefined>(undefined);
     const [selectedType, setSelectedType] = useState<PokemonType | undefined>(undefined);
+
+    function getRowClass(i: number, hover: boolean = false) {
+        return `${onMoveClick ? "cursor-pointer" : ""} ${hover ? "bg-blue-900" : i % 2 == 0 ? "" : "bg-gray-700"}`;
+    }
 
     return (
         <div>
@@ -85,7 +97,7 @@ export default function MoveTable({ moves, showLevel }: { moves: [number, Move][
                         </FilterOptionButton>
                     ))}
             </div>
-            <table className="w-full">
+            <table className="w-fit mx-auto">
                 <thead className="sticky top-0 text-gray-900 dark:text-gray-200 bg-blue-200 dark:bg-blue-700">
                     <tr>
                         {showLevel && <TableHeader>Lvl</TableHeader>}
@@ -109,7 +121,18 @@ export default function MoveTable({ moves, showLevel }: { moves: [number, Move][
                         )
                         .map(([level, m], index) => (
                             <Fragment key={index}>
-                                <tr className={index % 2 == 0 ? "" : "bg-gray-50 dark:bg-gray-700"}>
+                                <tr
+                                    className={getRowClass(index)}
+                                    onClick={() => onMoveClick?.(m)}
+                                    onMouseOver={(e) => {
+                                        e.currentTarget.className = getRowClass(index, true);
+                                        e.currentTarget.nextElementSibling!.className = getRowClass(index, true);
+                                    }}
+                                    onMouseOut={(e) => {
+                                        e.currentTarget.className = getRowClass(index);
+                                        e.currentTarget.nextElementSibling!.className = getRowClass(index);
+                                    }}
+                                >
                                     {showLevel && <TableCell>{level == 0 ? "E" : level}</TableCell>}
                                     <TableCell>
                                         <span className={m.isSignature ? "text-yellow-500" : ""}>{m.name}</span>
@@ -191,7 +214,18 @@ export default function MoveTable({ moves, showLevel }: { moves: [number, Move][
                                         </table>
                                     </TableCell>
                                 </tr>
-                                <tr className={index % 2 == 0 ? "" : "bg-gray-50 dark:bg-gray-700"}>
+                                <tr
+                                    className={getRowClass(index)}
+                                    onClick={() => onMoveClick?.(m)}
+                                    onMouseOver={(e) => {
+                                        e.currentTarget.className = getRowClass(index, true);
+                                        e.currentTarget.previousElementSibling!.className = getRowClass(index, true);
+                                    }}
+                                    onMouseOut={(e) => {
+                                        e.currentTarget.className = getRowClass(index);
+                                        e.currentTarget.previousElementSibling!.className = getRowClass(index);
+                                    }}
+                                >
                                     <TableCell span={showLevel ? 10 : 9} padding="px-1 pb-2">
                                         {m.description}
                                     </TableCell>

--- a/src/app/pokedex/page.tsx
+++ b/src/app/pokedex/page.tsx
@@ -29,6 +29,7 @@ import { PokemonType } from "../data/tectonic/PokemonType";
 import { TectonicData } from "../data/tectonic/TectonicData";
 import { Tribe } from "../data/tectonic/Tribe";
 import { uniq } from "../data/util";
+import MoveTable from "./components/MoveTable";
 import PokemonModal from "./components/PokemonModal";
 import PokemonTable from "./components/PokemonTable";
 import TabContent from "./components/TabContent";
@@ -174,7 +175,7 @@ const Home: NextPage = () => {
                     </p>
                 </div>
 
-                <div className="text-center p-1.5 w-max mx-auto sticky top-0 bg-gray-900">
+                <div className="text-center p-1.5 w-max mx-auto bg-gray-900">
                     {tabNames.map((n) => (
                         // not basic button
                         <button
@@ -206,44 +207,12 @@ const Home: NextPage = () => {
                     )}
                 </TabContent>
                 <TabContent tab="Moves" activeTab={activeTab}>
-                    <div className="overflow-x-auto">
-                        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                            <thead className="bg-gray-50 dark:bg-gray-800">
-                                <tr>
-                                    <TableHeader>Name</TableHeader>
-                                    <TableHeader>Type</TableHeader>
-                                    <TableHeader>Category</TableHeader>
-                                    <TableHeader>Power</TableHeader>
-                                    <TableHeader>Acc</TableHeader>
-                                    <TableHeader>PP</TableHeader>
-                                    <TableHeader>Effect</TableHeader>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {Object.values(TectonicData.moves).map((m) => (
-                                    <tr
-                                        key={m.id}
-                                        onClick={() => handleMoveClick(m)}
-                                        className={`cursor-pointer ${getTypeColorClass(m.type, "bg", "bg")}`}
-                                    >
-                                        <TableCell>{m.name}</TableCell>
-                                        <td className="text-center text-gray-500 dark:text-gray-400">
-                                            <TypeBadge
-                                                key={m.type.id}
-                                                types={[m.type]}
-                                                element={TypeBadgeElementEnum.CAPSULE_SINGLE}
-                                            />
-                                        </td>
-                                        <TableCell>{m.category}</TableCell>
-                                        <TableCell>{m.bp}</TableCell>
-                                        <TableCell>{m.accuracy}</TableCell>
-                                        <TableCell>{m.pp}</TableCell>
-                                        <TableCell>{m.description}</TableCell>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    </div>
+                    <div className="my-2"></div>
+                    <MoveTable
+                        moves={Object.values(TectonicData.moves).map((m) => [0, m])}
+                        showLevel={false}
+                        onMoveClick={handleMoveClick}
+                    />
                 </TabContent>
                 <TabContent tab="Abilities" activeTab={activeTab}>
                     <div className="overflow-x-auto">


### PR DESCRIPTION
Closes #205
Changed pokedex to use new move table. 

Lost some coloring as the background is no longer the move color. It's easy to get it back in but hard to get it to look good as it washes out the type icon and the category icon. Could find another way to add some flare with the move type color, but leaving as is for now

![image](https://github.com/user-attachments/assets/786dba1f-9856-4aa3-bc95-c1885435f1cf)
