### PR TITLE
Fixed null check for form stats

### DIFF
--- a/src/app/data/tectonic/Pokemon.ts
+++ b/src/app/data/tectonic/Pokemon.ts
@@ -175,7 +175,7 @@ export class Pokemon {
     public getType1 = getterFactory(this, "type1", (value: PokemonType) => value === PokemonType.NULL);
     public getType2 = getterFactory(this, "type2", (value: PokemonType) => value === PokemonType.NULL);
     public getAbilities = getterFactory(this, "abilities", (value: Ability[]) => value.length === 0);
-    public getStats = getterFactory(this, "stats", (value: Stats) => value === blankStats);
+    public getStats = getterFactory(this, "stats", (value: Stats) => value.hp === blankStats.hp); // Nothing should have 0 hp, so if it is 0 then it must not have been set
     public getPokedex = getterFactory(this, "pokedex", (value: string) => value === "");
     public getLevelMoves = getterFactory(this, "levelMoves", (value: [number, Move][]) => value.length === 0);
 


### PR DESCRIPTION
Closes #218 

Old issue unrelated to 3.3, the null check for stats not being set for a form would have been checking the actual reference object for `blankStats`, but the values coming from json build a new stat object everytime. So that would never be true for the null check. 

I've opted to just check if `hp == 0` because (in my mind) nothing will ever have 0 hp, so if it is 0 then it must not have been set in the form. 