### PR TITLE
Add proper handling for "Dry Skin" and similar abilities

### DIFF
--- a/src/app/data/abilities/MatchupModifyAbility.ts
+++ b/src/app/data/abilities/MatchupModifyAbility.ts
@@ -5,7 +5,7 @@ export abstract class MatchupModifyAbility extends Ability {
     protected affectedTypes: PokemonType[] = [];
     protected matchup: number = 1;
 
-    private affectsType(type: PokemonType) {
+    protected affectsType(type: PokemonType) {
         return this.affectedTypes.map((t) => t.id).includes(type.id);
     }
 

--- a/src/app/data/abilities/TypeImmunityAbility.ts
+++ b/src/app/data/abilities/TypeImmunityAbility.ts
@@ -27,8 +27,6 @@ const immunityAbilities: Record<string, string[]> = {
     SAPSIPPER: ["GRASS"],
     VOLTABSORB: ["ELECTRIC"],
     WATERABSORB: ["WATER"],
-    DRYSKIN: ["WATER"],
-    FINESUGAR: ["FIRE"],
     WONDERGUARD: ["QMARKS"],
     CYNIC: ["DRAGON", "FAIRY", "GHOST"],
     RUGGED: ["FIGHTING", "ROCK"],

--- a/src/app/data/abilities/TypeImmunityWeaknessAbility.ts
+++ b/src/app/data/abilities/TypeImmunityWeaknessAbility.ts
@@ -1,0 +1,23 @@
+import { LoadedAbility } from "@/preload/loadedDataClasses";
+import { PokemonType } from "../tectonic/PokemonType";
+import { TectonicData } from "../tectonic/TectonicData";
+import { MatchupModifyAbility } from "./MatchupModifyAbility";
+
+const immunityWeaknessAbilities: Record<string, string[]> = {
+    // immune type first, weak type second
+    DRYSKIN: ["WATER", "FIRE"],
+    FINESUGAR: ["FIRE", "WATER"],
+};
+
+export class TypeImmunityWeaknessAbility extends MatchupModifyAbility {
+    constructor(ability: LoadedAbility) {
+        super(ability);
+        this.affectedTypes = immunityWeaknessAbilities[ability.key].map((t) => TectonicData.types[t]);
+    }
+
+    public modifiedMatchup(type: PokemonType) {
+        return this.affectsType(type) ? (this.affectedTypes.findIndex((t) => t.id === type.id) === 0 ? 0 : 1.25) : 1;
+    }
+
+    static abilityIds = Object.keys(immunityWeaknessAbilities);
+}

--- a/src/app/data/abilities/TypeWeaknessAbility.ts
+++ b/src/app/data/abilities/TypeWeaknessAbility.ts
@@ -5,11 +5,6 @@ import { MatchupModifyAbility } from "./MatchupModifyAbility";
 const weaknessAbilities: Record<string, [number, string]> = {
     FLUFFY: [2, "FIRE"],
     PARANOID: [2, "PSYCHIC"],
-
-    // TODO: This doesn't actually work because the ability is also in the TypeImmunityAbility class and that one gets done first.
-    // Need to redesign how this is setup to make the abilty work for both immuinity and weakness
-    DRYSKIN: [1.25, "FIRE"],
-    FINESUGAR: [1.25, "WATER"],
 };
 
 export class TypeWeaknessAbility extends MatchupModifyAbility {

--- a/src/app/data/tectonic/TectonicData.ts
+++ b/src/app/data/tectonic/TectonicData.ts
@@ -6,6 +6,7 @@ import { STABBoostAbility } from "../abilities/STABBoostAbility";
 import { TwoItemAbility } from "../abilities/TwoItemAbility";
 import { TypeilateAbility } from "../abilities/TypeilateAbility";
 import { TypeImmunityAbility } from "../abilities/TypeImmunityAbility";
+import { TypeImmunityWeaknessAbility } from "../abilities/TypeImmunityWeaknessAbility";
 import { TypeResistAbility } from "../abilities/TypeResistAbility";
 import { TypeWeaknessAbility } from "../abilities/TypeWeaknessAbility";
 import { CategoryBoostingItem } from "../items/CategoryBoostingItem";
@@ -115,6 +116,7 @@ const abilitySubclasses = [
     TwoItemAbility,
     TypeilateAbility,
     TypeImmunityAbility,
+    TypeImmunityWeaknessAbility,
     TypeResistAbility,
     TypeWeaknessAbility,
 ];

--- a/src/app/data/typeChart.ts
+++ b/src/app/data/typeChart.ts
@@ -50,6 +50,8 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
     if (defAbility !== undefined) {
         if (defAbility instanceof MatchupModifyAbility) {
             defAbilityCalc *= defAbility.modifiedMatchup(atk.type);
+            console.log(defAbility.name);
+            console.log(defAbilityCalc);
             // certain moves pierce ground immunity
             if (defAbilityCalc === 0 && atk.move instanceof HitsFliersMove && atk.type.id === "GROUND") {
                 defAbilityCalc = 1;

--- a/src/app/data/typeChart.ts
+++ b/src/app/data/typeChart.ts
@@ -50,8 +50,6 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
     if (defAbility !== undefined) {
         if (defAbility instanceof MatchupModifyAbility) {
             defAbilityCalc *= defAbility.modifiedMatchup(atk.type);
-            console.log(defAbility.name);
-            console.log(defAbilityCalc);
             // certain moves pierce ground immunity
             if (defAbilityCalc === 0 && atk.move instanceof HitsFliersMove && atk.type.id === "GROUND") {
                 defAbilityCalc = 1;


### PR DESCRIPTION
Close #225 

A couple of issues:
- ~~There's no handling to convert a "1.25x" damage multiplier to anything nice-looking in the Pokedex. Theoretically if the ability somehow appeared on another Pokemon with different relationships to Fire or Water, that could create other edge cases too. Handling each of them uniquely is probably not feasible, we can leave it decimal, just gotta make it a *bit* nicer looking and colour the background.~~
- These abilities are seemingly have no effect in the damage calculator, only in the Pokedex, despite them calling the same `calcTypeMatchup` function iirc.