### PR TITLE
Local dev use local nextjs for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ If you contribute new/changes to images they'll need to be uploaded to the CDN (
 Images should also be added to the repo for safe keeping
 Note that Sirv has been configured for a 30 day local browser cache time. So if an image gets updated it may be delayed for users unless they force a refresh.
 
--   This applies to you for local dev as well, force refreshing locally will consume our free tier limit
+-   Local dev should always use the localhost nextjs server, unless you use a production version locally

--- a/src/components/ImageFallback.tsx
+++ b/src/components/ImageFallback.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { ReactNode, useState } from "react";
 
 // Keep adding fallbacks till we can serve everyone for free?
@@ -26,7 +27,29 @@ export default function ImageFallback({
     const [isCDNErrorTryGithub, setIsCDNErrorTryGithub] = useState<boolean>(false);
     const [isError, setError] = useState<boolean>(false);
 
-    return (
+    // Non prod builds should force use Image so we don't use up CDN limits
+    return process.env.NODE_ENV !== "production" ? (
+        <Image
+            alt={alt}
+            title={title}
+            src={isError ? IMG_NOT_FOUND : src}
+            onError={() => {
+                if (!isCDNErrorTryGithub) {
+                    setIsCDNErrorTryGithub(true);
+                } else {
+                    setError(true);
+                }
+            }}
+            width={width}
+            height={height}
+            className={className}
+            onClick={onClick}
+            onContextMenu={(e) => {
+                onContextMenu?.();
+                e.preventDefault();
+            }}
+        />
+    ) : (
         <img
             alt={alt}
             title={title}


### PR DESCRIPTION
Just so contributors don't have to worry about accidentally taking up CDN limits
Works for `npm run dev`. If you do a `npm start` then you'll be hitting the CDN

Also provides pattern of what it would look like to use nextjs (like we were before) as another fallback for images if the CDNs are out.

Sorry for PR spam on this, but really wanted to get this in so I don't accidentally take up a bunch of our CDN space doing random stuff!