### PR TITLE
Added steam power to resisted abilities list

### DIFF
--- a/src/app/data/abilities/TypeResistAbility.ts
+++ b/src/app/data/abilities/TypeResistAbility.ts
@@ -10,6 +10,7 @@ const halfDmgAbilities: Record<string, string[]> = {
     UNAFRAID: ["DARK", "BUG"],
     THICKFAT: ["FIRE", "ICE"],
     WATERBUBBLE: ["FIRE"],
+    STEAMPOWER: ["WATER"],
 };
 
 export class TypeResistAbility extends MatchupModifyAbility {


### PR DESCRIPTION
Steam power was missing, nows properly shows only double dmg instead of x4