### PR TITLE
Add Vercel as img source

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Live at https://tectonic.alphakretin.com
 ## Contributor
 
 If you contribute new/changes to images they'll need to be uploaded to the CDN (Sirv) to be available.
-Images should also be added to the repo for safe keeping
+Images should also be added to the repo as well both for safe keeping and since it's for both local dev and a backup for serving
 Note that Sirv has been configured for a 30 day local browser cache time. So if an image gets updated it may be delayed for users unless they force a refresh.
 
 -   Local dev should always use the localhost nextjs server, unless you use a production version locally

--- a/src/components/ImageFallback.tsx
+++ b/src/components/ImageFallback.tsx
@@ -51,8 +51,8 @@ export default function ImageFallback({
     }
 
     function getImageSourceString(): string {
-        var root = "";
-        var img = src;
+        let root = "";
+        let img = src;
 
         switch (sourceState) {
             case ImageSourceState.Vercel:

--- a/src/components/ImageFallback.tsx
+++ b/src/components/ImageFallback.tsx
@@ -2,9 +2,17 @@ import Image from "next/image";
 import { ReactNode, useState } from "react";
 
 // Keep adding fallbacks till we can serve everyone for free?
-const IMG_CDN_ROOT = "https://tectonictools.sirv.com/Images/public/";
-const IMG_GITHUB_FALLBACK = "https://raw.githubusercontent.com/AlphaKretin/tectonic-tools/refs/heads/main/public/";
+const IMG_SIRV_ROOT = "https://tectonictools.sirv.com/Images/public";
+const IMG_GITHUB_FALLBACK = "https://raw.githubusercontent.com/AlphaKretin/tectonic-tools/refs/heads/main/public";
 export const IMG_NOT_FOUND = "/Items/NOTFOUND.png";
+
+enum ImageSourceState {
+    Vercel,
+    Sirv,
+    Github,
+    Error,
+}
+
 export default function ImageFallback({
     alt,
     src,
@@ -24,57 +32,89 @@ export default function ImageFallback({
     onClick?: () => void;
     onContextMenu?: () => void;
 }): ReactNode {
-    const [isCDNErrorTryGithub, setIsCDNErrorTryGithub] = useState<boolean>(false);
-    const [isError, setError] = useState<boolean>(false);
+    const [sourceState, setSourceState] = useState<ImageSourceState>(ImageSourceState.Vercel);
+
+    function toNextSourceState() {
+        switch (sourceState) {
+            case ImageSourceState.Vercel:
+                setSourceState(ImageSourceState.Sirv);
+                return;
+            case ImageSourceState.Sirv:
+                setSourceState(ImageSourceState.Github);
+                return;
+            case ImageSourceState.Github:
+                setSourceState(ImageSourceState.Error);
+                return;
+            case ImageSourceState.Error:
+                return;
+        }
+    }
+
+    function getImageSourceString(): string {
+        var root = "";
+        var img = src;
+
+        switch (sourceState) {
+            case ImageSourceState.Vercel:
+                break;
+            case ImageSourceState.Sirv:
+                root = IMG_SIRV_ROOT;
+                break;
+            case ImageSourceState.Github:
+                root = IMG_GITHUB_FALLBACK;
+                break;
+            case ImageSourceState.Error:
+                root = IMG_GITHUB_FALLBACK;
+                img = IMG_NOT_FOUND;
+                break;
+        }
+
+        return root + img;
+    }
+
+    function getNextJsImage(): ReactNode {
+        return (
+            <Image
+                alt={alt}
+                title={title}
+                src={getImageSourceString()}
+                onError={() => toNextSourceState()}
+                width={width}
+                height={height}
+                className={className}
+                onClick={onClick}
+                onContextMenu={(e) => {
+                    onContextMenu?.();
+                    e.preventDefault();
+                }}
+            />
+        );
+    }
+
+    function getHtmlImage() {
+        return (
+            <img
+                alt={alt}
+                title={title}
+                loading="lazy"
+                src={getImageSourceString()}
+                onError={() => toNextSourceState()}
+                width={width}
+                height={height}
+                className={className}
+                onClick={onClick}
+                onContextMenu={(e) => {
+                    onContextMenu?.();
+                    e.preventDefault();
+                }}
+            />
+        );
+    }
 
     // Non prod builds should force use Image so we don't use up CDN limits
-    return process.env.NODE_ENV !== "production" ? (
-        <Image
-            alt={alt}
-            title={title}
-            src={isError ? IMG_NOT_FOUND : src}
-            onError={() => {
-                if (!isCDNErrorTryGithub) {
-                    setIsCDNErrorTryGithub(true);
-                } else {
-                    setError(true);
-                }
-            }}
-            width={width}
-            height={height}
-            className={className}
-            onClick={onClick}
-            onContextMenu={(e) => {
-                onContextMenu?.();
-                e.preventDefault();
-            }}
-        />
-    ) : (
-        <img
-            alt={alt}
-            title={title}
-            src={
-                isCDNErrorTryGithub
-                    ? `${IMG_GITHUB_FALLBACK}${src}`
-                    : isError
-                    ? `${IMG_CDN_ROOT}${IMG_NOT_FOUND}`
-                    : `${IMG_CDN_ROOT}${src}`
-            }
-            onError={() => {
-                if (!isCDNErrorTryGithub) {
-                    setIsCDNErrorTryGithub(true);
-                } else {
-                    setError(true);
-                }
-            }}
-            width={width}
-            height={height}
-            className={className}
-            onClick={onClick}
-            onContextMenu={(e) => {
-                onContextMenu?.();
-                e.preventDefault();
-            }}
-        />
-    );
+    if (process.env.NODE_ENV !== "production") {
+        return getNextJsImage();
+    }
+
+    return sourceState == ImageSourceState.Vercel ? getNextJsImage() : getHtmlImage();
 }


### PR DESCRIPTION
I'm gunna say this closes #237 . Can make another one if it's needed (I really sure do hope it's not)

Adds Vercel as the main image source to take advantage of `<Image` and our 5000 image transforms. The fallback system works as follows
- Try Vercel
- Try Sirv
  - Looking at our stats 2/3 of the way through the month we are over 3GB... We only get 2 per month (after first month) lol. Hopefully with vercel support & it handling populating some users local caches we will be able to support everyone
- Try Github
- Rip

Also added lazy loading for `<img`. This should reduce the load on Sirv a bit if it comes to it. Also speeds up page load when relying on Sirv. Also also helps with the fallback system as doing a request to a new source after falling back will naturally take more time (so lazy loading it should help).

I tested with a single bulbasaur img so as to not spam Sirv. I'm not 100% sure what the error vercel gives when rate limited, but the fallback system worked for when images were not found. The error handler is for any error, so I'm assuming it'll work the same for a rate limit return. 