### PR TITLE
SP And Level Input Improvements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,7 @@ body {
 
 @theme {
     --color-yellow-highlight: #ffd166;
+    --color-value-out-of-range: #fb2c36;
 
     --color-fire: #e4613e;
     --color-fire-bg: #8a211c;

--- a/src/components/PokemonCardHorizontal.tsx
+++ b/src/components/PokemonCardHorizontal.tsx
@@ -6,11 +6,11 @@ import { TypeChangingItem } from "@/app/data/items/TypeChangingItem";
 import { MAX_LEVEL, MAX_SP, MIN_LEVEL, MIN_SP, STYLE_POINT_CAP, styleFromStat } from "@/app/data/teamExport";
 import { Item } from "@/app/data/tectonic/Item";
 import { Move } from "@/app/data/tectonic/Move";
-import { Pokemon, StylePoints, zeroStylePoints } from "@/app/data/tectonic/Pokemon";
+import { Pokemon, Stats, StylePoints, zeroStylePoints } from "@/app/data/tectonic/Pokemon";
 import { TectonicData } from "@/app/data/tectonic/TectonicData";
 import { PartyPokemon } from "@/app/data/types/PartyPokemon";
 import { isNull, negativeMod, safeKeys } from "@/app/data/util";
-import { useState } from "react";
+import { ChangeEvent, useState } from "react";
 import { getTypeColorClass } from "./colours";
 import Dropdown from "./DropDown";
 import ImageFallback from "./ImageFallback";
@@ -19,6 +19,17 @@ import PokemonModal from "./PokemonModal";
 import CloseXButton from "./svg_icons/CloseXButton";
 import TribeCapsule from "./TribeCapsule";
 import TypeBadge, { TypeBadgeElementEnum } from "./TypeBadge";
+
+const stylePointPresets: Record<string, StylePoints> = {
+    Custom: zeroStylePoints,
+    Flat: { hp: 10, attacks: 10, speed: 10, defense: 10, spdef: 10 },
+    "Fast Atk": { hp: 10, attacks: 20, speed: 20, defense: 0, spdef: 0 },
+    "Bulk Atk": { hp: 20, attacks: 20, speed: 10, defense: 0, spdef: 0 },
+    "Phys Tank": { hp: 10, attacks: 20, speed: 0, defense: 20, spdef: 0 },
+    "Sp Tank": { hp: 10, attacks: 20, speed: 0, defense: 0, spdef: 20 },
+    "Phys Wall": { hp: 20, attacks: 0, speed: 0, defense: 20, spdef: 10 },
+    "Sp Wall": { hp: 20, attacks: 0, speed: 0, defense: 10, spdef: 20 },
+};
 
 export default function PokemonCardHorizontal({
     partyMon,
@@ -31,6 +42,7 @@ export default function PokemonCardHorizontal({
 }) {
     const [modalMon, setModalMon] = useState<Pokemon | null>(null);
     const [moveIndex, setMoveIndex] = useState<number | null>(null);
+    const [stylePreset, setStylePreset] = useState<string>("");
 
     function showInfoModal() {
         setMoveIndex(null);
@@ -49,16 +61,31 @@ export default function PokemonCardHorizontal({
         setModalMon(null);
     }
 
-    function spSum(sp: StylePoints): number {
-        return Object.values(sp).reduce((total, x) => total + x, 0);
+    function onSpUpdate(k: keyof Stats, e: ChangeEvent<HTMLInputElement>) {
+        partyMon.stylePoints = {
+            ...partyMon.stylePoints,
+            [styleFromStat(k)]: e.target.value == "" ? 0 : parseInt(e.target.value),
+        };
+
+        let foundPreset = false;
+        for (const preset in stylePointPresets) {
+            if (JSON.stringify(stylePointPresets[preset]) == JSON.stringify(partyMon.stylePoints)) {
+                setStylePreset(preset);
+
+                foundPreset = true;
+                break;
+            }
+        }
+
+        if (!foundPreset) {
+            setStylePreset("Custom");
+        }
+
+        onUpdate();
     }
 
-    function updateSP(stat: keyof StylePoints, value: number) {
-        const newSP = { ...partyMon.stylePoints, [stat]: value };
-        if (spSum(newSP) <= STYLE_POINT_CAP && value >= MIN_SP && value <= MAX_SP) {
-            partyMon.stylePoints = newSP;
-            onUpdate();
-        }
+    function spDiffFromTotal(sp: StylePoints): number {
+        return STYLE_POINT_CAP - Object.values(sp).reduce((total, x) => total + x, 0);
     }
 
     return (
@@ -237,57 +264,89 @@ export default function PokemonCardHorizontal({
                 </tbody>
             </table>
 
-            <table className="w-full text-center text-white">
+            <table className="table-fixed text-center text-white">
                 <thead>
                     <tr className="bg-blue-900">
                         <th>Lvl</th>
                         <th>HP</th>
                         <th>Atk</th>
-                        <th>Sp. Atk</th>
-                        <th>Speed</th>
+                        <th>Sp.A</th>
+                        <th>Spe</th>
                         <th>Def</th>
-                        <th>Sp. Def</th>
+                        <th>Sp.D</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr className="bg-gray-900">
-                        <td className="w-10">
+                        <td
+                            className={`${
+                                partyMon.level > MAX_LEVEL || partyMon.level < MIN_LEVEL
+                                    ? "text-value-out-of-range"
+                                    : ""
+                            }`}
+                        >
                             <input
-                                type="number"
-                                min={MIN_LEVEL}
-                                max={MAX_LEVEL}
+                                className="w-36 text-center"
                                 value={partyMon.level}
                                 onChange={(e) => {
-                                    const value = parseInt(e.target.value);
-                                    partyMon.level = value >= MIN_LEVEL && value <= MAX_LEVEL ? value : partyMon.level;
+                                    partyMon.level = e.target.value == "" ? 0 : parseInt(e.target.value);
                                     onUpdate();
                                 }}
                             />
                         </td>
                         {safeKeys(partyMon.getBaseStats()).map((k) => (
-                            <td key={k} className="w-15">
+                            <td key={k} className="text-center">
                                 {partyMon.getStats()[k]}
                             </td>
                         ))}
                     </tr>
                     <tr className="bg-emerald-700">
                         <td
-                            className="bg-emerald-800 cursor-pointer"
-                            onClick={() => {
-                                partyMon.stylePoints = zeroStylePoints;
-                                onUpdate();
-                            }}
+                            className={`bg-emerald-800 cursor-pointer ${
+                                spDiffFromTotal(partyMon.stylePoints) < 0 ? "text-value-out-of-range" : ""
+                            }`}
                         >
-                            SP {STYLE_POINT_CAP - spSum(partyMon.stylePoints)}
+                            <select
+                                className="w-23 mr-1"
+                                value={stylePreset}
+                                onChange={(e) => {
+                                    const preset = e.target.value;
+                                    setStylePreset(preset);
+
+                                    partyMon.stylePoints = {
+                                        ...stylePointPresets[preset],
+                                    };
+                                    onUpdate();
+                                }}
+                            >
+                                {Object.keys(stylePointPresets).map((x) => (
+                                    <option key={x} value={x}>
+                                        {x}
+                                    </option>
+                                ))}
+                            </select>
+                            <span
+                                className="pr-1"
+                                onClick={() => {
+                                    setStylePreset("Custom");
+                                    partyMon.stylePoints = zeroStylePoints;
+                                    onUpdate();
+                                }}
+                            >
+                                SP {spDiffFromTotal(partyMon.stylePoints)}
+                            </span>
                         </td>
                         {safeKeys(partyMon.getBaseStats()).map((k) => (
                             <td key={k}>
                                 <input
-                                    type="number"
-                                    min={MIN_SP}
-                                    max={MAX_SP}
+                                    className={`w-13 text-center ${
+                                        partyMon.stylePoints[styleFromStat(k)] < MIN_SP ||
+                                        partyMon.stylePoints[styleFromStat(k)] > MAX_SP
+                                            ? "text-value-out-of-range"
+                                            : ""
+                                    }`}
                                     value={partyMon.stylePoints[styleFromStat(k)]}
-                                    onChange={(e) => updateSP(styleFromStat(k), parseInt(e.target.value))}
+                                    onChange={(e) => onSpUpdate(k, e)}
                                 />
                             </td>
                         ))}


### PR DESCRIPTION
Closes #246 
Closes #264 

SP and Levels now
- Can be free entered only (no +/- input box)
- Removing the last value via backspace auto sets to 0
- Typing a new number when it's 0 will clear the 0 value and set only the number
- Can exceed the min/max values. In practice this mostly just means the max because you can't enter a negative value (since `-` isn't a digit)
- Text becomes red when not in the proper range
- SP presets implemented via drop down selection
  - They also are automatically chosen if you manually enter the values

It's a bit hard to describe what this feels like now. Easiest to just pull and try yourself. 
Tabbing through the fields is pretty quick though for settings values
<img width="466" height="82" alt="image" src="https://github.com/user-attachments/assets/519ea3f8-997a-4dc0-bb51-e7b520371575" />
