### PR TITLE
implement MUTANT and fix extra type bug

### DIFF
--- a/src/app/data/abilities/ExtraTypeAbility.ts
+++ b/src/app/data/abilities/ExtraTypeAbility.ts
@@ -8,6 +8,7 @@ const isAlsoTypeAbilities: Record<string, string> = {
     INFECTED: "GRASS",
     RUSTWRACK: "STEEL",
     SLUGGISH: "BUG",
+    UNIDENTIFIED: "MUTANT",
 };
 
 export class ExtraTypeAbility extends Ability {

--- a/src/app/data/typeChart.ts
+++ b/src/app/data/typeChart.ts
@@ -54,10 +54,17 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
             defAbilityCalc = 1;
         }
 
-        if (defAbility instanceof ExtraTypeAbility) {
+        if (
+            defAbility instanceof ExtraTypeAbility
+        ) {
             const defType3 = defAbility.extraType;
-            defAbilityCalc = TectonicData.typeChart[atkType.index][defType3.index];
-            thirdType = defType3;
+            if (
+                defType3.id !== defType1.id &&
+                defType3.id !== def.type2?.id
+            ) {
+                defAbilityCalc = TectonicData.typeChart[atkType.index][defType3.index];
+                thirdType = defType3;
+            }
         }
 
         if (defAbility.id == "WONDERGUARD" && defType1Calc * defType2Calc <= 1) {


### PR DESCRIPTION
resolves #276 

there was also previously a bug, where if e.g. Dhelmise had Rust & Wrack and CV Steel it would become defensively a Steel/Steel type. this is corrected now