### PR TITLE
Fix for checking the version bits

### DIFF
--- a/src/app/data/pokeparty.ts
+++ b/src/app/data/pokeparty.ts
@@ -110,8 +110,8 @@ export class PokePartyEncoding {
         versionU16 |= (parseInt(versionSplit[2]) & 0x1f) << VERSION_PATCH_SHIFT;
 
         const data: [number, BytesRequired][] = [
-            [pokePartyEncodingU8, BytesRequired.U8],
             [pokePartyVersionU8, BytesRequired.U8],
+            [pokePartyEncodingU8, BytesRequired.U8],
             [versionU16, BytesRequired.U16],
         ];
         for (const pokemon of party.filter((x) => x.species.id != Pokemon.NULL.id)) {
@@ -194,7 +194,7 @@ export class PokePartyEncoding {
                 return decodeTeam(base64);
             }
 
-            const encoding = ((view.getUint8(0) & ENCODING_MASK) >>> ENCODING_SHIFT) as PokePartyEncodingType;
+            const encoding = ((view.getUint8(1) & ENCODING_MASK) >>> ENCODING_SHIFT) as PokePartyEncodingType;
             let offset = VERSION_BYTES;
             while (offset < view.byteLength) {
                 const mon = new PartyPokemon();


### PR DESCRIPTION
Very quickly
- Old format stored tectonic version as a u16 **big endian**
- New decoder checks to see if the major of that version has a non-0 value, if so it knows it's an old code
- The major is stored at the first 5bits
- In big endian for a u16 those first 5 bits are actually the second byte, not the first... whoops
- Somehow, by sheer luck, @AlphaKretin the 3.4.0-dev version puts the patch for of `0` (ie. 0 5 bits) along side the `100` zeroes from `4` right where the major was, creating 5 bits of 0