### PR TITLE
Export team to full tectonic code - downloaded as a file

### DIFF
--- a/src/app/data/pokeparty.ts
+++ b/src/app/data/pokeparty.ts
@@ -104,7 +104,7 @@ export class PokePartyEncoding {
         const pokePartyEncodingU8 = encoding << ENCODING_SHIFT;
         const pokePartyVersionU8 = POKE_PARTY_FORMAT_VERSION;
         const versionSplit = TectonicData.version.replace("dev", "").split(".");
-        let versionU16 = TectonicData.version.includes("-dev") ? VERSION_DEV_MASK : 0;
+        let versionU16 = TectonicData.isDev ? VERSION_DEV_MASK : 0;
         versionU16 |= (parseInt(versionSplit[0]) & 0x1f) << VERSION_MAJOR_SHIFT;
         versionU16 |= (parseInt(versionSplit[1]) & 0x1f) << VERSION_MINOR_SHIFT;
         versionU16 |= (parseInt(versionSplit[2]) & 0x1f) << VERSION_PATCH_SHIFT;

--- a/src/app/data/teamExport.ts
+++ b/src/app/data/teamExport.ts
@@ -114,7 +114,7 @@ function encodeChunk(version: VersionMap, view: DataView<ArrayBuffer>, byteOffse
 
     third_u32 |= getMonMoveShiftValue(2, MOVE3_SHIFT, MOVE3_MASK);
     third_u32 |= getMonMoveShiftValue(3, MOVE4_SHIFT, MOVE4_MASK);
-    third_u32 |= ((data.items.length > 0 ? heldItems[data.items[0].id] ?? -1 : -1) << ITEM1_SHIFT) & ITEM1_MASK;
+    third_u32 |= ((data.items.length > 0 ? (heldItems[data.items[0].id] ?? -1) : -1) << ITEM1_SHIFT) & ITEM1_MASK;
     third_u32 |= (hasSecondItem ? 1 : 0) << FLAG_HAS_2_ITEM_SHIFT;
     third_u32 |= (hasItem1Type ? 1 : 0) << FLAG_HAS_ITEM1_TYPE_SHIFT;
     third_u32 |= (hasForm ? 1 : 0) << FLAG_HAS_FORM_SHIFT;
@@ -145,7 +145,7 @@ export function encodeTeam(party: PartyPokemon[]): string {
     const view = new DataView(new ArrayBuffer(1, { maxByteLength: MAX_TEAM_BYTES }));
 
     const versionSplit = TectonicData.version.replace("dev", "").split(".");
-    let versionU16 = TectonicData.version.includes("-dev") ? VERSION_DEV_MASK : 0;
+    let versionU16 = TectonicData.isDev ? VERSION_DEV_MASK : 0;
     versionU16 |= (parseInt(versionSplit[0]) & 0x1f) << VERSION_MAJOR_SHIFT;
     versionU16 |= (parseInt(versionSplit[1]) & 0x1f) << VERSION_MINOR_SHIFT;
     versionU16 |= (parseInt(versionSplit[2]) & 0x1f) << VERSION_PATCH_SHIFT;
@@ -166,7 +166,7 @@ const decodeChunk = (
     version: VersionMap,
     view: DataView<ArrayBuffer>,
     byteOffset: number,
-    party: PartyPokemon[]
+    party: PartyPokemon[],
 ): number => {
     const mon = new PartyPokemon();
 

--- a/src/app/data/tectonic/Item.ts
+++ b/src/app/data/tectonic/Item.ts
@@ -16,7 +16,7 @@ export class Item {
     image: string = "";
 
     get isHeldItem() {
-        if (TectonicData.version.includes("-dev")) {
+        if (TectonicData.isDev) {
             return this.pocket >= 9 && this.pocket <= 13;
         }
         return this.pocket == 5;

--- a/src/app/data/tectonic/TectonicData.ts
+++ b/src/app/data/tectonic/TectonicData.ts
@@ -144,6 +144,7 @@ function fromLoadedArray<L extends LoadedData<L>, T>(load: Record<string, L[]>, 
 
 type TectonicDataType = {
     version: string;
+    isDev: boolean;
     types: Record<string, PokemonType>;
     tribes: Record<string, Tribe>;
     abilities: Record<string, Ability>;
@@ -166,6 +167,7 @@ type TectonicDataType = {
 // To this end, the data not in-line loaded with TectonicData (left as {}) is done that way because it requires TectonicData to be instanciated first to populate
 export const TectonicData: TectonicDataType = {
     version: data.version,
+    isDev: data.version.includes("-dev"),
     types: fromLoaded(data.types, PokemonType),
     tribes: fromLoaded(data.tribes, Tribe),
     trainerTypes: fromLoaded(data.trainerTypes, TrainerType),
@@ -217,7 +219,7 @@ Trainer.NULL = new Trainer();
 
 // Start of post-load population
 Object.entries(TectonicData.forms).forEach(([k, v]) => TectonicData.pokemon[k].addForms([Pokemon.NULL, ...v]));
-if (TectonicData.version.includes("-dev")) {
+if (TectonicData.isDev) {
     TectonicData.heldItems = Object.values(TectonicData.items).filter((x) => x.pocket >= 9 && x.pocket <= 13);
 } else {
     TectonicData.heldItems = Object.values(TectonicData.items).filter((x) => x.pocket == 5);

--- a/src/components/DownloadFileButton.tsx
+++ b/src/components/DownloadFileButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ReactNode } from "react";
+import BasicButton from "./BasicButton";
+
+export default function DownloadFileButton({
+    filename,
+    generateContent,
+    children,
+}: {
+    filename: string;
+    generateContent: () => string;
+    children: ReactNode;
+}) {
+    const handleDownload = () => {
+        const blob = new Blob([generateContent()], { type: "text/plain;charset=utf-8" });
+        const href = URL.createObjectURL(blob);
+
+        const link = document.createElement("a");
+        link.href = href;
+        link.download = filename;
+
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+
+        URL.revokeObjectURL(href);
+    };
+
+    return <BasicButton onClick={handleDownload}>{children}</BasicButton>;
+}

--- a/src/components/SavedTeamManager.tsx
+++ b/src/components/SavedTeamManager.tsx
@@ -1,8 +1,10 @@
-import { PokePartyEncoding } from "@/app/data/pokeparty";
+import { PokePartyEncoding, PokePartyEncodingType } from "@/app/data/pokeparty";
 import { Pokemon } from "@/app/data/tectonic/Pokemon";
+import { TectonicData } from "@/app/data/tectonic/TectonicData";
 import { PartyPokemon } from "@/app/data/types/PartyPokemon";
 import { JSX, useCallback, useEffect, useState } from "react";
 import BasicButton from "./BasicButton";
+import DownloadFileButton from "./DownloadFileButton";
 
 const teamManagementLocalStorageKeyV1 = "TeamManagementLocalStorageKey_V1";
 const pokePartyLocalStorageV1 = "PokePartyLocalStorageKey_V1";
@@ -127,6 +129,14 @@ export default function SavedTeamManager({
                 <div className="flex gap-2">
                     <BasicButton onClick={() => importTeam(teamCode)}>Import</BasicButton>
                     {exportMons && <BasicButton onClick={exportTeam}>Export</BasicButton>}
+                    {TectonicData.isDev && exportMons && (
+                        <DownloadFileButton
+                            filename="teamcode.txt"
+                            generateContent={() => PokePartyEncoding.encode(exportMons!, PokePartyEncodingType.Full)}
+                        >
+                            Export for Tectonic
+                        </DownloadFileButton>
+                    )}
                 </div>
             </div>
 


### PR DESCRIPTION
Closes #365 

Downloads the team as a file. Done with a new button component so that we can extend this later to PBS downloads with some groundwork complete.

Pls pls pls double check that this **only shows when the data is a dev version**. I checked locally ofc, only saw the button when my loaded json data was for dev.

Only thing I've noticed that might be kinda annoying (not really a way to work around it though) is that download the file again will of course download it to the users downloads location again. Where they may already have this file downloaded - in which case it'll do the ol' append an `(x)` to the file name for whatever x number of download this is. 