### PR TITLE
Fix team code crash when importing ids that map to undefined

### DIFF
--- a/src/app/data/pokeparty.ts
+++ b/src/app/data/pokeparty.ts
@@ -254,8 +254,7 @@ export class PokePartyEncoding {
                         TectonicData.abilities,
                         Ability.NULL,
                     );
-                    mon.moves[0] =
-                        move1Id == 0 ? Move.NULL : (TectonicData.moves[decodingMapping.moves[move1Id]] ?? Move.NULL);
+                    mon.moves[0] = TectonicData.moves[decodingMapping.moves[move1Id]] ?? Move.NULL;
                     mon.moves[1] = decodeMapId(
                         "moves",
                         secondU32,
@@ -379,5 +378,5 @@ function decodeMapId<T>(
     def: T,
 ): T {
     const key = (u32 & mask) >>> shift;
-    return key == 0 ? def : (tectonicDataRecord[decodingMapping[category][key]] ?? def);
+    return tectonicDataRecord[decodingMapping[category][key]] ?? def;
 }


### PR DESCRIPTION
Only affects the short form team code as what's happening here is the mapping is not finding the key provided and is returning undefined. 

Changed to use the `XYZ.NULL` value for the data, that way when the UI encounters it it just displays the default values for that data instead of crashing. 