### PR TITLE
Add optional battleState to calcTypeMatchup

### DIFF
--- a/src/app/damagecalc/components/MoveCard.tsx
+++ b/src/app/damagecalc/components/MoveCard.tsx
@@ -104,7 +104,7 @@ export default function MoveCard(props: MoveCardProps): ReactNode {
                 className={`flex w-full justify-between items-center p-1 rounded-2xl ${getTypeColorClass(
                     props.moveData.move.getType(props.user, props.battleState),
                     "bg",
-                    "bg"
+                    "bg",
                 )} ${props.moveData.move.isSTAB(props.user) ? "font-bold" : ""} ${
                     props.moveData.move.isSignature ? "text-yellow-300" : ""
                 }`}
@@ -117,7 +117,7 @@ export default function MoveCard(props: MoveCardProps): ReactNode {
                     />
                     <ImageFallback
                         src={Move.getMoveCategoryImgSrc(
-                            props.moveData.move.getDamageCategory(props.moveData, props.user, props.target)
+                            props.moveData.move.getDamageCategory(props.moveData, props.user, props.target),
                         )}
                         alt={props.moveData.move.category}
                         title={props.moveData.move.category}
@@ -130,7 +130,7 @@ export default function MoveCard(props: MoveCardProps): ReactNode {
                 <div
                     className={`p-1 whitespace-nowrap rounded-xl border-1 border-white/50 ${getColourClassForMult(
                         result.typeEffectMult,
-                        "bg-gray-500"
+                        "bg-gray-500",
                     )} ${getTextColourForMult(result.typeEffectMult)}`}
                 >
                     <div className="flex gap-2 items-center">
@@ -163,18 +163,22 @@ export default function MoveCard(props: MoveCardProps): ReactNode {
                         props.user,
                         props.target,
                         props.battleState,
-                        props.moveData.customVar
+                        props.moveData.customVar,
                     )}`}</span>
-                    <span>{`Accuracy: ${props.battleState.gravity && props.moveData.move.accuracy > 0 ? Math.min(props.moveData.move.accuracy * 2, 100) : props.moveData.move.accuracy}%`}</span>
+                    {props.moveData.move.accuracy > 0 && (
+                        <span>{`Accuracy: ${props.battleState.gravity ? Math.min(props.moveData.move.accuracy * 2, 100) : props.moveData.move.accuracy}%`}</span>
+                    )}
                 </div>
                 <div className="flex flex-col">
                     <span>{`Priority: ${props.moveData.move.priority ?? "None"}`}</span>
-                    <span>{`Flags: ${props.moveData.move.getDisplayFlags(", ")}`}</span>
+                    {props.moveData.move.getDisplayFlags(", ").length > 0 && (
+                        <span>{`Flags: ${props.moveData.move.getDisplayFlags(", ")}`}</span>
+                    )}
                 </div>
                 <div
                     className={`flex flex-col items-end px-2 rounded-xl border-1 border-white/50 ${getColourClassForMult(
                         result.typeEffectMult,
-                        "bg-gray-500"
+                        "bg-gray-500",
                     )} ${getTextColourForMult(result.typeEffectMult)}`}
                 >
                     {getDmgNode()}

--- a/src/app/damagecalc/components/MoveCard.tsx
+++ b/src/app/damagecalc/components/MoveCard.tsx
@@ -165,7 +165,7 @@ export default function MoveCard(props: MoveCardProps): ReactNode {
                         props.battleState,
                         props.moveData.customVar
                     )}`}</span>
-                    <span>{`Accuracy: ${props.moveData.move.accuracy}%`}</span>
+                    <span>{`Accuracy: ${props.battleState.gravity && props.moveData.move.accuracy > 0 ? Math.min(props.moveData.move.accuracy * 2, 100) : props.moveData.move.accuracy}%`}</span>
                 </div>
                 <div className="flex flex-col">
                     <span>{`Priority: ${props.moveData.move.priority ?? "None"}`}</span>

--- a/src/app/damagecalc/damageCalc.ts
+++ b/src/app/damagecalc/damageCalc.ts
@@ -574,7 +574,8 @@ function pbCalcTypeBasedDamageMultipliers(
     // variable type moves are handled here in Tectonic, but on the data level here
     const effectiveness = calcTypeMatchup(
         { type: type, move: move.move, abilities: user.getActiveAbilities() },
-        { type1: target.types.type1, type2: target.types.type2, abilities: target.getActiveAbilities() }
+        { type1: target.types.type1, type2: target.types.type2, abilities: target.getActiveAbilities() },
+        battleState
     );
     multipliers.final_damage_multiplier *= effectiveness;
 

--- a/src/app/data/abilities/TypeImmunityAbility.ts
+++ b/src/app/data/abilities/TypeImmunityAbility.ts
@@ -1,5 +1,7 @@
+import { BattleState } from "@/app/data/battleState";
 import { LoadedAbility } from "@/app/data/loadedDataClasses";
 import { TectonicData } from "../tectonic/TectonicData";
+import { PokemonType } from "../tectonic/PokemonType";
 import { MatchupModifyAbility } from "./MatchupModifyAbility";
 
 const immunityAbilities: Record<string, string[]> = {
@@ -31,13 +33,31 @@ const immunityAbilities: Record<string, string[]> = {
     CYNIC: ["DRAGON", "FAIRY", "GHOST"],
     RUGGED: ["FIGHTING", "ROCK"],
     RESOLUTE: ["DARK", "BUG"],
+    WINTERINSULATION: ["FIRE", "ELECTRIC"],
+    DESICCATE: ["WATER", "GRASS"],
+    DECONTAMINATION: ["BUG", "POISON"],
+};
+
+type ImmunityCondition = (battleState?: BattleState) => boolean;
+
+const immunityConditions: Record<string, ImmunityCondition> = {
+    WINTERINSULATION: (bs) => bs?.weather === "Hail",
+    DESICCATE: (bs) => bs?.weather === "Sandstorm",
+    DECONTAMINATION: (bs) => bs?.weather === "Moonglow" || bs?.weather === "Blood Moon",
 };
 
 export class TypeImmunityAbility extends MatchupModifyAbility {
     matchup = 0;
+    private condition: ImmunityCondition;
+
     constructor(ability: LoadedAbility) {
         super(ability);
         this.affectedTypes = immunityAbilities[ability.key].map((t) => TectonicData.types[t]);
+        this.condition = immunityConditions[ability.key] ?? (() => true);
+    }
+
+    public modifiedMatchup(type: PokemonType, battleState?: BattleState) {
+        return this.affectsType(type) && this.condition(battleState) ? 0 : 1;
     }
 
     static abilityIds = Object.keys(immunityAbilities);

--- a/src/app/data/moves/WeightTargetScalingMove.ts
+++ b/src/app/data/moves/WeightTargetScalingMove.ts
@@ -1,12 +1,14 @@
+import { BattleState } from "@/app/data/battleState";
 import { Move } from "../tectonic/Move";
 import { PartyPokemon } from "../types/PartyPokemon";
 
 export class WeightTargetScalingMove extends Move {
-    public getPower(_: PartyPokemon, target: PartyPokemon): number {
+    public getPower(_: PartyPokemon, target: PartyPokemon, battleState: BattleState): number {
         let ret = 15;
         // Formula differs from Tectonic - they store weight in kg/10ths
         // we store kg directly
-        const weight = Math.min(target.species.weight, 2000);
+        const baseWeight = target.species.weight * (battleState.gravity ? 2 : 1);
+        const weight = Math.min(baseWeight, 2000);
         ret += Math.floor((4 * Math.sqrt(weight)) / 5) * 5;
         return ret;
     }

--- a/src/app/data/tectonic/Ability.ts
+++ b/src/app/data/tectonic/Ability.ts
@@ -25,7 +25,7 @@ export class Ability {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public modifiedMatchup(type: PokemonType) {
+    public modifiedMatchup(type: PokemonType, battleState?: BattleState) {
         return 1;
     }
 

--- a/src/app/data/typeChart.ts
+++ b/src/app/data/typeChart.ts
@@ -49,7 +49,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData, battleStat
     // Process all defender abilities (supports Fragile Locket dual abilities)
     for (const defAbility of def.abilities ?? []) {
         // Apply modifiedMatchup from each ability
-        defAbilityCalc *= defAbility.modifiedMatchup(atk.type);
+        defAbilityCalc *= defAbility.modifiedMatchup(atk.type, battleState);
         if (defAbilityCalc === 0 && piercesGroundImmunity) {
             defAbilityCalc = 1;
         }

--- a/src/app/data/typeChart.ts
+++ b/src/app/data/typeChart.ts
@@ -2,6 +2,7 @@ import { ExtraTypeAbility } from "./abilities/ExtraTypeAbility";
 import { ExtraEffectiveMove } from "./moves/ExtraEffectiveMove";
 import { ExtraTypeMove } from "./moves/ExtraTypeMove";
 import { HitsFliersMove } from "./moves/HitsFliersMove";
+import { BattleState } from "./battleState";
 import { Ability } from "./tectonic/Ability";
 import { Move } from "./tectonic/Move";
 import { PokemonType } from "./tectonic/PokemonType";
@@ -22,16 +23,16 @@ interface DefenderData {
 }
 
 // Calculates the best mult value given all attacker moves in that case
-export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
+export function calcTypeMatchup(atk: AttackerData, def: DefenderData, battleState?: BattleState) {
     const atkType = atk.type;
     const defType1 = def.type1;
     let thirdType: PokemonType | null = null;
 
-    let defType1Calc = TectonicData.typeChart[atkType.index][defType1.index];
+    // HitsFliers moves and Gravity both pierce all Ground-type immunities
+    const piercesGroundImmunity = atk.type.id === "GROUND" && (atk.move instanceof HitsFliersMove || !!battleState?.gravity);
 
-    // certain moves pierce ground immunity
-    // TODO: Revisit this to make it more generic when e.g. gravity is implemented
-    if (atk.move instanceof HitsFliersMove && atk.type.id === "GROUND") {
+    let defType1Calc = TectonicData.typeChart[atkType.index][defType1.index];
+    if (piercesGroundImmunity) {
         defType1Calc = Math.max(defType1Calc, 1);
     }
 
@@ -40,8 +41,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
     if (def.type2 !== undefined) {
         const defType2 = def.type2;
         defType2Calc = TectonicData.typeChart[atkType.index][defType2.index];
-        // certain moves pierce ground immunity
-        if (atk.move instanceof HitsFliersMove && atk.type.id === "GROUND") {
+        if (piercesGroundImmunity) {
             defType2Calc = Math.max(defType2Calc, 1);
         }
     }
@@ -50,8 +50,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
     for (const defAbility of def.abilities ?? []) {
         // Apply modifiedMatchup from each ability
         defAbilityCalc *= defAbility.modifiedMatchup(atk.type);
-        // certain moves pierce ground immunity
-        if (defAbilityCalc === 0 && atk.move instanceof HitsFliersMove && atk.type.id === "GROUND") {
+        if (defAbilityCalc === 0 && piercesGroundImmunity) {
             defAbilityCalc = 1;
         }
 
@@ -115,7 +114,7 @@ export function calcTypeMatchup(atk: AttackerData, def: DefenderData) {
 
         if (atkMove instanceof ExtraTypeMove) {
             // should not recur by a depth of more than 1, since move is no longer defined
-            atkMoveCalc *= calcTypeMatchup({ type: atkMove.extraType, abilities: atkAbilities }, def);
+            atkMoveCalc *= calcTypeMatchup({ type: atkMove.extraType, abilities: atkAbilities }, def, battleState);
         }
     }
 


### PR DESCRIPTION
Allows for matchups to be conditional on battle elements, e.g. Gravity or abilities that check the weather
If battleStat isn't passed, it will be ignored, allowing the function to still be used for static type analysis like in the Pokedex
Fix #252